### PR TITLE
Commits not attributed to owner

### DIFF
--- a/.github/workflows/stuff.yml
+++ b/.github/workflows/stuff.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Add to git repo
         run: |
           git add .
-          git config --global user.name "Akshit Garg"
-          git config --global user.email "garg.akshit@gmail.com"
+          git config --global user.name "readme-bot"
+          git config --global user.email "readme-bot@example.com"
           git commit -m "[Magic] Automated README update"
 
       - name: Push


### PR DESCRIPTION
I noticed your commit chart is filling up because of your readme activity.

A lot of people are unaware that you can attribute the commits to a non-existant account and they will still go through perfectly fine. If you want the commits to oversaturate your commit graph, you can safely ignore this PR, but if you're looking for an easy fix then this will work for you.

Love the project's creativity, cheers!